### PR TITLE
Fix printing of booleans for 'data' format.

### DIFF
--- a/lib/JMX/Jmx4Perl/Util.pm
+++ b/lib/JMX/Jmx4Perl/Util.pm
@@ -93,7 +93,7 @@ sub dump_scalar {
 
     if (JSON::is_bool($value)) {
         my ($true,$false) = split /\//,$format;
-        if ($value eq "true") {
+        if ($value eq JSON::true) {
             return $true; 
         } else {
             return $false;


### PR DESCRIPTION
When using the default 'data' format all boolean values
are reported as '[false]'. When using 'json' format
boolean values are correctly reported as 'false' or 'true'.

The problem is in lib/JMX/Jmx4Perl/Util.pm:
JSON::is_bool is used to determin if a value is a boolean.
If so the value is compared against the string 'true' and
formated to either '[false]' or '[true]'. This comparison
failes and returns always '[false]'.

Changing the comparison to '$value eq JSON::true' produces
the correct result.

Testing against constant JSON::true should be safe, as
JSON::is_bool only returns true if the value represents
either JSON::true or JSON::false (see perldoc JSON, is_bool).
