### PR TITLE
Change reg expression to support http request containing user:pwd

### DIFF
--- a/lib/JMX/Jmx4Perl/J4psh/ServerHandler.pm
+++ b/lib/JMX/Jmx4Perl/J4psh/ServerHandler.pm
@@ -40,7 +40,7 @@ sub connect_to_server {
     my $server_map = $self->{server_map};
     my $s = $server_map->{$server};
     unless ($s) {
-        unless ($server =~ m|^\w+://[\d\.\w:]+(:(\d+))?/|) {
+        unless ($server =~ m|^\w+://([\w]+:\w+@)?[\d\.\w:]+(:(\d+))?/|) {
             print "Invalid URL $server\n";
             return;
         }


### PR DESCRIPTION
Update the reg expression to support http url containing admin:password@

Tested with these connect instructions

````
[j4psh] : connect http://admin:admin@localhost:8181/hawtio/jolokia
Connected to admin:admin@localhost:8181 (http://admin:admin@localhost:8181/hawtio/jolokia).
[admin:admin@localhost:8181] : quit
dabou:~$ j4psh
[j4psh] : connect http://localhost:8181/hawtio/jolokia
403 Forbidden.
````