### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,9 @@ RUN apk add --update \
     gnupg1 \
  && cpan App::cpanminus < /dev/null \
  && cpanm install -n Term::ReadKey \
+    # pin Term-Clui version, the 1.71 has a broken META.yml
+    # cf. https://rt.cpan.org/Public/Bug/Display.html?id=120160
+ && cpanm PJB/Term-Clui-1.70.tar.gz \
  && cpanm install \
     JSON::XS \
     Term::ReadLine::Gnu \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --update \
     libxml2-dev \
     expat-dev \
     gnupg1 \
+    openssl-dev \
  && cpan App::cpanminus < /dev/null \
  && cpanm install -n Term::ReadKey \
     # pin Term-Clui version, the 1.71 has a broken META.yml
@@ -25,6 +26,7 @@ RUN apk add --update \
  && cpanm install \
     JSON::XS \
     Term::ReadLine::Gnu \
+    LWP::Protocol::https \
     XML::LibXML \
  && cpanm install ROLAND/jmx4perl-${JMX4PERL_VERSION}.tar.gz \
  && rm -rf /var/cache/apk/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@
 # ==================================================
 FROM alpine:3.2
 
-ENV JMX4PERL_VERSION 1.12
+# The less command from alpine does not interpret color escapes (no -R switch)
+ENV JMX4PERL_VERSION=1.12 PAGER=cat
 
 RUN apk add --update \
     build-base \


### PR DESCRIPTION
Hello Roland,

first of all: thank you for all the effort you put into jmx4perl and jolokia.

I would like to suggest a couple of changes to the docker build file. At least on my system the published docker image "jolokia/jmx4perl:latest" did not work properly: `jolokia download` failed due to missing https support.

When I tried to adapt the `Dockerfile` I ran into this other issue with the broken `Term-Clui 1.71`.

Apart from that, `jolokia info jolokia.war` on the published docker image complained: _No XML::LibXML found. Please install it to allow changes and queries on web.xml_ -- I see this has already been fixed in commit 0188e96591f6bfd09fbb79db330425bc6ad78dcf but the published docker image is a couple of hours older than that commit (2015-07-28 17:33 versus 19:42 [UTC]). This explains why I encountered this problem.

So, this PR only deals with the first two issues mentioned above. The third problem can be solved by updating the docker image on Docker Hub.

Kind regards,
Joachim